### PR TITLE
Make sure java-syntax apply to *.java files

### DIFF
--- a/syntax/java.vim
+++ b/syntax/java.vim
@@ -4,7 +4,7 @@
 
 if version < 600
     syntax clear
-elseif exists("b:current_syntax")
+elseif exists("b:current_syntax") && b:current_syntax == 'java-syntax.vim'
     finish
 endif
 


### PR DESCRIPTION
I've found that current java-syntax.vim version not working on recent vim version(master branch), so I made a simple fix.